### PR TITLE
Fix gdax.fetch_ohlcv

### DIFF
--- a/python/ccxt/gdax.py
+++ b/python/ccxt/gdax.py
@@ -334,7 +334,8 @@ class gdax (Exchange):
             if limit is None:
                 # https://docs.gdax.com/#get-historic-rates
                 limit = 350  # max = 350
-            request['end'] = self.ymdhms(self.sum(limit * granularity * 1000, since))
+            # request['end'] = self.ymdhms(self.sum(limit * granularity * 1000, since))
+            request['end'] = self.ymdhms((limit * granularity * 1000) + since)
         response = self.publicGetProductsIdCandles(self.extend(request, params))
         return self.parse_ohlcvs(response, market, timeframe, since, limit)
 


### PR DESCRIPTION
The existing gdax.fetch_ohlcv() incorrectly calculates the request['end'] timestamp by using self.sum.

The patch fixes this by calculating the request['end'] timestamp with: ((limit * granularity * 1000) + since)